### PR TITLE
Fixed not found error by adding juce namespace to AudioProcessorListener

### DIFF
--- a/include/cmajor/helpers/cmaj_JUCEPlugin.h
+++ b/include/cmajor/helpers/cmaj_JUCEPlugin.h
@@ -449,7 +449,7 @@ private:
 
     void handlePatchChange()
     {
-        auto changes = AudioProcessorListener::ChangeDetails::getDefaultFlags();
+        auto changes = juce::AudioProcessorListener::ChangeDetails::getDefaultFlags();
 
         auto newLatency = (int) patch->getFramesLatency();
 


### PR DESCRIPTION
I had this error compiling version 1.0.2397 (latest):
```
/cmajor/include/cmajor/helpers/cmaj_JUCEPlugin.h:452:24 Use of undeclared identifier 'AudioProcessorListener'; did you mean 'juce::AudioProcessorListener'?
```
Adding juce:: namespace fixed it for me