### PR TITLE
Returning loadPatch value from JUCEPluginBase

### DIFF
--- a/include/cmajor/helpers/cmaj_JUCEPlugin.h
+++ b/include/cmajor/helpers/cmaj_JUCEPlugin.h
@@ -114,13 +114,17 @@ public:
             setNewStateAsync (createEmptyState (fileToLoad));
     }
 
-    void loadPatch (const PatchManifest& manifest)
+    bool loadPatch (const PatchManifest& manifest)
     {
         if (dllLoadedSuccessfully)
         {
             Patch::LoadParams loadParams;
             loadParams.manifest = manifest;
-            patch->loadPatch (loadParams);
+            return patch->loadPatch (loadParams);
+        }
+        else
+        {
+            return false;
         }
     }
 


### PR DESCRIPTION
The return value of Patch::loadPatch (https://github.com/cmajor-lang/cmajor/blob/main/include/cmajor/helpers/cmaj_Patch.h#L1914) is a boolean indicating whether the patch is playable or not

This return value would be useful for code using the JUCEPluginBase but is currently swallowed in JUCEPluginBase::loadPatch (https://github.com/cmajor-lang/cmajor/blob/main/include/cmajor/helpers/cmaj_JUCEPlugin.h#L117), which returns void

This PR forwards the value from the Patch out through the Plugin method