### PR TITLE
Make Cmajor library relocatable on Linux

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -324,6 +324,7 @@ function (MAKE_CMAJ_LIBRARY)
         endforeach()
     elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         target_link_options(${CMAJ_LIBRARY_NAME} INTERFACE "-Wl,--exclude-libs,ALL")
+        set_property(TARGET ${CMAJ_LIBRARY_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
     endif()
 
     target_sources(${CMAJ_LIBRARY_NAME} PRIVATE ${CMAJ_MODULE_DIR}/../3rdParty/graphviz/cmaj_GraphViz.cpp)


### PR DESCRIPTION
Hi,

I've tried building Cmajor on Kubuntu Linux 22.04.4 with GCC 11.4, and I got the following error regarding a linker failure.

```
/usr/bin/ld: tools/CmajDLL/CMakeFiles/performer_cmaj_lib.dir/__/__/modules/compiler/src/diagnostics/cmaj_ErrorHandling.cpp.o: relocation R_X86_64_TPOFF32 against `_ZN4cmajL13activeHandlerE' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
```

As the compiler suggested, I've added the missing flag to the Cmajor library to make it position-independent.