### PR TITLE
Fix C++ codegen omitting struct types only reachable through an inlined external constant

### DIFF
--- a/modules/compiler/src/AST/cmaj_AST_Utilities.h
+++ b/modules/compiler/src/AST/cmaj_AST_Utilities.h
@@ -858,6 +858,24 @@ struct Dependencies
             addDependencies (ref->getTarget());
         }
 
+        // Follow the result type of constant values. When an external variable is
+        // resolved to a compile-time constant — e.g. inlined by the C++ backend
+        // rather than kept in runtime storage — it becomes a ConstantAggregate
+        // whose struct element types can be otherwise unreachable from the
+        // function body. Without this they never enter `structs`, and the emitted
+        // C++ references an undeclared type. (The LLVM backend is unaffected: it
+        // builds its types lazily.)
+        if (auto cv = o.getAsConstantValueBase())
+            if (auto t = cv->getResultType())
+                addDependencies (*t);
+
+        // Follow the types referenced by any type (array/vector element, struct
+        // members, alias target) so that reaching a type pulls in everything it
+        // structurally depends on.
+        if (auto type = o.getAsTypeBase())
+            for (auto& referenced : type->getResolvedReferencedTypes())
+                addDependencies (referenced);
+
         const_cast<AST::Object&> (o).visitObjectsInScope ([this] (Object& s)
         {
             addDependencies (s);


### PR DESCRIPTION
### Summary

`cmaj generate --target=cpp` can emit C++ that references a struct type which is never declared, producing `use of undeclared identifier` at compile time. It happens when a **specialised** processor (compile-time parameter) indexes an `external` array of structs: the external is resolved to a compile-time `ConstantAggregate` and inlined, and a struct type that appears only inside that constant — e.g. a nested struct reached through an array member, never named by a function-body expression — is never added to the codegen's dependency set.

The LLVM JIT backend is unaffected (it builds types lazily); only the C++ codegen backend, which must emit explicit struct declarations, breaks.

### Repro

`repro.cmajor`:
```cmajor
namespace demo
{
    struct Inner { float[4] data; }
    struct Outer { Inner[2] items; int32 tag; }   // Inner appears only via the array member
    external Outer[2] table;
}

processor Voice (int slot)                         // specialised: `slot` is compile-time
{
    input value float idx;
    output stream float out;

    void main()
    {
        loop
        {
            let j = clamp (int (idx), 0, 1);
            // table.at(slot) folds to a constant Outer value (slot is compile-time),
            // dropping the variable reference. .items.at(j) member-accesses that
            // constant at a runtime index, so Inner survives only as a constant's type.
            out <- demo::table.at (slot).items.at (j).data[0];
            advance();
        }
    }
}

graph Main [[ main ]]
{
    output stream float out;
    node a = Voice(0);
    node b = Voice(1);
    connection { a.out -> out;  b.out -> out; }
}
```

`repro.cmajorpatch`:
```json
{ "CmajorVersion": 1, "ID": "com.demo.repro", "version": "0.1", "name": "Repro", "source": "repro.cmajor",
  "externals": { "demo::table": [ { "tag": 1, "items": [ { "data": [1,2,3,4] }, { "data": [5,6,7,8] } ] },
                                   { "tag": 2, "items": [ { "data": [9,10,11,12] }, { "data": [13,14,15,16] } ] } ] } }
```

```
cmaj generate --target=cpp --output=out.cpp repro.cmajorpatch
clang++ -std=c++17 -fsyntax-only out.cpp
# error: use of undeclared identifier 'demo_Inner'
```

The generated C++ inlines `Array<demo_Inner, 2> { demo_Inner { ... } }` but never declares `struct demo_Inner`. Reading at a **runtime** index instead (so the external stays a variable reference) does not trigger it — the variable reference anchors the type via `visitObjectsInScope`.

### Root cause

`AST::Dependencies::addDependencies` (`modules/compiler/src/AST/cmaj_AST_Utilities.h`) collects the structs/functions the backend must emit by walking function bodies and `visitObjectsInScope`. It never follows:

- a `ConstantValue`'s result type, nor
- the types structurally referenced by a type (array/vector element, struct members, alias target).

So a struct reachable only through an inlined external constant is missed.

### Fix

Follow `getAsConstantValueBase()->getResultType()` and `getAsTypeBase()->getResolvedReferencedTypes()` in `addDependencies`. 18 lines, no behavior change for the LLVM backend.

### Verification

Built `cmaj` with and without the change from the same base and ran `cmaj generate --target=cpp` on the repro: without it the output fails `clang++ -std=c++17 -fsyntax-only` (`use of undeclared identifier`); with it the struct is declared and compilation succeeds.
